### PR TITLE
feat(evals): add regex evaluator

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/metrics/__init__.py
+++ b/packages/phoenix-evals/src/phoenix/evals/metrics/__init__.py
@@ -1,11 +1,13 @@
 from .document_relevance import DocumentRelevanceEvaluator
 from .exact_match import exact_match
 from .hallucination import HallucinationEvaluator
+from .matches_regex import MatchesRegex
 from .precision_recall import PrecisionRecallFScore
 
 __all__ = [
     "exact_match",
-    "HallucinationEvaluator",
-    "PrecisionRecallFScore",
     "DocumentRelevanceEvaluator",
+    "HallucinationEvaluator",
+    "MatchesRegex",
+    "PrecisionRecallFScore",
 ]

--- a/packages/phoenix-evals/src/phoenix/evals/metrics/matches_regex.py
+++ b/packages/phoenix-evals/src/phoenix/evals/metrics/matches_regex.py
@@ -1,0 +1,103 @@
+import re
+from typing import (
+    List,
+    Optional,
+    Pattern,  # import from re module when we drop support for 3.8
+    Union,
+)
+
+from pydantic import BaseModel, Field
+
+from ..evaluators import EvalInput, Evaluator, Score
+
+
+class MatchesRegex(Evaluator):
+    """Evaluates whether text output matches a specified regular expression pattern.
+
+    This heuristic evaluator checks if the output contains one or more substrings that
+    match a given regex pattern. It returns a binary score (1.0 for match, 0.0 for no match)
+    along with an explanation of which substrings matched or that no match was found.
+
+    Args:
+        pattern: The regular expression pattern to match against. Can be provided as
+            a string or a compiled Pattern object.
+        name: Optional custom name for the evaluator. If not provided, defaults to
+            "matches_regex".
+        include_explanation: Whether to include an explanation in the Score object.
+            Defaults to True.
+
+    Examples:
+        Basic usage with URL detection::
+
+            from phoenix.evals.metrics.matches_regex import MatchesRegex
+
+            # Create a regex evaluator to check if output contains a link
+            contains_link = MatchesRegex(pattern=r"https?://[^\\s]+")
+
+            eval_input = {
+                "output": "Here is the official site: https://openai.com"
+            }
+
+            scores = contains_link.evaluate(eval_input)
+            print(scores)
+            # [Score(
+            #     name='matches_regex',
+            #     score=1.0,
+            #     explanation="the substrings ['https://openai.com'] matched the regex pattern https?://[^\\s]+",
+            #     source='heuristic',
+            #     direction='maximize'
+            # )]
+    """
+
+    class InputSchema(BaseModel):
+        output: str = Field(..., description="The output to the LLM.")
+
+    def __init__(
+        self,
+        pattern: Union[str, Pattern[str]],
+        name: Optional[str] = None,
+        include_explanation: bool = True,
+    ):
+        """Initialize the regex evaluator.
+
+        Args:
+            pattern: The regex pattern (string or compiled Pattern).
+            name: Optional name for the evaluator. Defaults to "matches_regex".
+        """
+        if isinstance(pattern, str):
+            pattern = re.compile(pattern)
+
+        self.pattern = pattern
+        self.include_explanation = include_explanation
+        eval_name = name or "matches_regex"
+
+        super().__init__(
+            name=eval_name,
+            source="heuristic",
+            input_schema=self.InputSchema,
+            direction="maximize",
+        )
+
+    def _evaluate(self, eval_input: EvalInput) -> List[Score]:
+        output = eval_input["output"]
+
+        matches = self.pattern.findall(output)
+
+        if matches:
+            explanation = (
+                f"the substrings {matches} matched the regex pattern {self.pattern.pattern}"
+            )
+            score_value = 1.0
+        else:
+            explanation = f"no substrings matched the regex pattern {self.pattern.pattern}"
+            score_value = 0.0
+
+        return [
+            Score(
+                score=score_value,
+                name=self.name,
+                explanation=explanation if self.include_explanation else None,
+                source=self.source,
+                direction=self.direction,
+            )
+        ]

--- a/packages/phoenix-evals/tests/phoenix/evals/metrics/test_matches_regex.py
+++ b/packages/phoenix-evals/tests/phoenix/evals/metrics/test_matches_regex.py
@@ -1,0 +1,90 @@
+import re
+from typing import Any, Dict, List
+
+import pytest
+
+from phoenix.evals.metrics import MatchesRegex
+
+
+def _scores_by_name(scores: List[Any]) -> Dict[str, float]:
+    return {s.name: s.score for s in scores}
+
+
+@pytest.mark.parametrize(
+    "description, kwargs, output, expected_names, expected_scores, expected_explanation",
+    [
+        pytest.param(
+            "phone number match",
+            dict(pattern=r"\+?\d{1,3}[- ]?\d{3}[- ]?\d{3}[- ]?\d{4}"),
+            "Call me at +1-800-555-1234 tomorrow.",
+            ["matches_regex"],
+            dict(matches_regex=1.0),
+            "the substrings ['+1-800-555-1234'] matched the regex pattern \\+?\\d{1,3}[- ]?\\d{3}[- ]?\\d{3}[- ]?\\d{4}",
+            id="phone-number",
+        ),
+        pytest.param(
+            "github repo url match",
+            dict(pattern=r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+"),
+            "Check out https://github.com/Arize-ai/phoenix for the source code.",
+            ["matches_regex"],
+            dict(matches_regex=1.0),
+            "the substrings ['https://github.com/Arize-ai/phoenix'] matched the regex pattern https://github\\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+",
+            id="github-link-arize-phoenix",
+        ),
+        pytest.param(
+            "email address match",
+            dict(pattern=r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"),
+            "Send feedback to test.user@example.com please.",
+            ["matches_regex"],
+            dict(matches_regex=1.0),
+            "the substrings ['test.user@example.com'] matched the regex pattern [a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}",
+            id="email-address",
+        ),
+        pytest.param(
+            "empty string no match",
+            dict(pattern=r"\d+"),
+            "",
+            ["matches_regex"],
+            dict(matches_regex=0.0),
+            "no substrings matched the regex pattern \\d+",
+            id="empty-string-no-match",
+        ),
+    ],
+)
+def test_matches_regex_success(
+    description: str,
+    kwargs: Dict[str, Any],
+    output: str,
+    expected_names: List[str],
+    expected_scores: Dict[str, float],
+    expected_explanation: str,
+) -> None:
+    evaluator = MatchesRegex(**kwargs)
+    scores = evaluator.evaluate({"output": output})
+    names = [s.name for s in scores]
+
+    assert names == expected_names
+    by_name = _scores_by_name(scores)
+
+    for key, expected in expected_scores.items():
+        assert by_name[key] == pytest.approx(expected, rel=1e-6, abs=1e-12)
+
+    if expected_explanation is not None:
+        assert expected_explanation in scores[0].explanation
+    else:
+        assert scores[0].explanation is None
+
+
+@pytest.mark.parametrize(
+    "description, kwargs",
+    [
+        pytest.param(
+            "invalid regex pattern string raises re.error",
+            dict(pattern="("),
+            id="invalid-pattern",
+        ),
+    ],
+)
+def test_matches_regex_errors(description: str, kwargs: Dict[str, Any]) -> None:
+    with pytest.raises(re.error):
+        _ = MatchesRegex(**kwargs)


### PR DESCRIPTION
resolves #9658

Used class-based Evaluator instead of @create_evaluator decorator because the regex pattern is a config parameter, not row data.

Why class-based:
- Pattern is set once when creating the evaluator
- Only 'output' changes per row in the dataframe
- Avoids repeating the same pattern in every row

With decorator approach, we'd need:
```py
df = pd.DataFrame({
    "output": ["foo123", "bar456"],
    "pattern": ["\\d+", "\\d+"]  # duplicated!
})
```

With class approach, we can do:
```py
checker = RegexMatchEvaluator(pattern="\\d+")
df = pd.DataFrame({"output": ["foo123", "bar456"]})
results = evaluate_dataframe(df, [checker])
```