### PR TITLE
Fix column selector dropdown overflow for CSV datasets with many columns

### DIFF
--- a/app/src/pages/datasets/DatasetFromCSVForm.tsx
+++ b/app/src/pages/datasets/DatasetFromCSVForm.tsx
@@ -345,6 +345,7 @@ function ColumnMultiSelector(
               onChange(Array.from(keys) as string[]);
             }}
             selectedKeys={new Set(selectedColumns)}
+            style={{ maxHeight: "40vh", overflowY: "auto" }}
           >
             {columns.map((column) => (
               <Item key={column}>{column}</Item>


### PR DESCRIPTION
### Changes
- Added scrolling functionality to the ColumnMultiSelector dropdown
- Applied responsive max-height constraint (40vh) with vertical overflow scroll

### Problem
When uploading CSV datasets with a large number of columns (10+), the column selector dropdown would overflow beyond the viewport, making it inconvenient to select columns that appeared below the fold.

### Solution
Applied a max-height constraint using viewport-relative units (40% of viewport height) and vertical scrolling to the ListBox component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the ColumnMultiSelector dropdown to limit its height and enable vertical scrolling, improving readability and navigation for long column lists.
  - Prevents the dropdown from overflowing the page, maintaining a cleaner and more consistent layout across screens.
  - Enhances usability by making it easier to browse and select columns without excessive scrolling of the entire page.
  - No changes to selection behavior or data handling; visual-only refinement for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->