### PR TITLE
feat: validate template variables match dataframe columns in run_evals

### DIFF
--- a/packages/phoenix-evals/src/phoenix/evals/legacy/classify.py
+++ b/packages/phoenix-evals/src/phoenix/evals/legacy/classify.py
@@ -430,6 +430,21 @@ def run_evals(
             "`from phoenix.evals.legacy import LLMEvaluator`"
         )
 
+    available_columns = set(dataframe.columns)
+
+    # Validate that each evaluator has all required template fields
+    for evaluator in evaluators:
+        required_fields = set(evaluator._template.variables)
+
+        missing_fields = required_fields - available_columns
+
+        if missing_fields:
+            raise ValueError(
+                f"Evaluator '{evaluator.__class__.__name__}' requires missing columns: "
+                f"{', '.join(sorted(missing_fields))}. "
+                f"Available columns: {', '.join(sorted(available_columns))}"
+            )
+
     # use the minimum default concurrency of all the models
     if concurrency is None:
         if len(evaluators) == 0:


### PR DESCRIPTION
This prevents confusing KeyError exceptions and helps users quickly identify DataFrame/template mismatches.

- Added validation to ensure all template variables match DataFrame columns before running evaluators
- Raises descriptive ValueError when missing columns are detected, listing both missing and available columns
- Includes test case to verify validation behavior