### PR TITLE
replace HTTP 404 with clear error message for missing prompts

### DIFF
--- a/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
@@ -118,7 +118,7 @@ class Prompts:
             prompt_response.raise_for_status()
         except HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise ValueError(f"Prompt not found: {prompt_identifier or prompt_version_id}")
+                raise ValueError(f"Prompt not found: {prompt_version_id or prompt_identifier}")
             raise
         return PromptVersion._loads(cast(v1.GetPromptResponseBody, prompt_response.json())["data"])  # pyright: ignore[reportPrivateUsage]
 
@@ -389,7 +389,7 @@ class AsyncPrompts:
             prompt_response.raise_for_status()
         except HTTPStatusError as e:
             if e.response.status_code == 404:
-                raise ValueError(f"Prompt not found: {prompt_identifier or prompt_version_id}")
+                raise ValueError(f"Prompt not found: {prompt_version_id or prompt_identifier}")
             raise
         return PromptVersion._loads(cast(v1.GetPromptResponseBody, prompt_response.json())["data"])  # pyright: ignore[reportPrivateUsage]
 

--- a/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
@@ -4,6 +4,7 @@ import logging
 from typing import Optional, cast
 
 import httpx
+from httpx import HTTPStatusError
 
 from phoenix.client.__generated__ import v1
 from phoenix.client.types.prompts import PromptVersion
@@ -90,6 +91,7 @@ class Prompts:
             PromptVersion: The retrieved prompt version data.
 
         Raises:
+            ValueError: If prompt identifier or prompt version id is not found.
             httpx.HTTPStatusError: If the HTTP request returned an unsuccessful status code.
 
         Example::
@@ -111,9 +113,14 @@ class Prompts:
             )
         """
         url = _url(prompt_version_id, prompt_identifier, tag)
-        response = self._client.get(url)
-        response.raise_for_status()
-        return PromptVersion._loads(cast(v1.GetPromptResponseBody, response.json())["data"])  # pyright: ignore[reportPrivateUsage]
+        try:
+            prompt_response = self._client.get(url)
+            prompt_response.raise_for_status()
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ValueError(f"Prompt not found: {prompt_identifier or prompt_version_id}")
+            raise
+        return PromptVersion._loads(cast(v1.GetPromptResponseBody, prompt_response.json())["data"])  # pyright: ignore[reportPrivateUsage]
 
     def create(
         self,
@@ -355,6 +362,7 @@ class AsyncPrompts:
             PromptVersion: The retrieved prompt version data.
 
         Raises:
+            ValueError: If prompt identifier or prompt version id is not found.
             httpx.HTTPStatusError: If the HTTP request returned an unsuccessful status code.
 
         Example::
@@ -376,9 +384,14 @@ class AsyncPrompts:
             )
         """
         url = _url(prompt_version_id, prompt_identifier, tag)
-        response = await self._client.get(url)
-        response.raise_for_status()
-        return PromptVersion._loads(cast(v1.GetPromptResponseBody, response.json())["data"])  # pyright: ignore[reportPrivateUsage]
+        try:
+            prompt_response = self._client.get(url)
+            prompt_response.raise_for_status()
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise ValueError(f"Prompt not found: {prompt_identifier or prompt_version_id}")
+            raise
+        return PromptVersion._loads(cast(v1.GetPromptResponseBody, prompt_response.json())["data"])  # pyright: ignore[reportPrivateUsage]
 
     async def create(
         self,

--- a/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
+++ b/packages/phoenix-client/src/phoenix/client/resources/prompts/__init__.py
@@ -385,7 +385,7 @@ class AsyncPrompts:
         """
         url = _url(prompt_version_id, prompt_identifier, tag)
         try:
-            prompt_response = self._client.get(url)
+            prompt_response = await self._client.get(url)
             prompt_response.raise_for_status()
         except HTTPStatusError as e:
             if e.response.status_code == 404:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt retrieval error handling: missing prompts now raise a clear "Prompt not found" error instead of a generic HTTP error for both synchronous and asynchronous calls.
  * Ensured consistent behavior between sync and async prompt retrieval flows.

* **Documentation**
  * Updated docstrings to document the not-found error behavior for both sync and async retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->